### PR TITLE
surrounding li menu items with a ul wrapper

### DIFF
--- a/src/components/commons/Menu/styles/MenuWrapper.js
+++ b/src/components/commons/Menu/styles/MenuWrapper.js
@@ -50,7 +50,7 @@ MenuWrapper.LeftSide = styled.div`
   })}
 `;
 
-MenuWrapper.Central = styled.div`
+MenuWrapper.Central = styled.ul`
   padding: 0;
   margin: 0;
   order: 3;


### PR DESCRIPTION
At menu Component the list of links was builded with li html tags, and before, the wrapper `MenuWrapper.Central` was a div, and to improve accessibility is better surround li tags with a ul wrapper.